### PR TITLE
fix(casify): fix casify to also return original task name

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,31 +1,41 @@
 {
-  "projectName": "p-s",
-  "projectOwner": "kentcdodds",
-  "files": [
+  "projectName": "p-s"
+, "projectOwner": "kentcdodds"
+, "files": [
     "README.md"
-  ],
-  "imageSize": 100,
-  "commit": false,
-  "contributors": [
+  ]
+, "imageSize": 100
+, "commit": false
+, "contributors": [
     {
-      "login": "kentcdodds",
-      "name": "Kent C. Dodds",
-      "avatar_url": "https://avatars.githubusercontent.com/u/1500684?v=3",
-      "profile": "http://kent.doddsfamily.us",
-      "contributions": [
-        "code",
-        "doc",
-        "infra",
-        "example"
-      ]
-    },
-    {
-      "login": "DavidWells",
-      "name": "David Wells",
-      "avatar_url": "https://avatars.githubusercontent.com/u/532272?v=3",
-      "profile": "http://davidwells.io",
-      "contributions": [
+      "login": "kentcdodds"
+    , "name": "Kent C. Dodds"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/1500684?v=3"
+    , "profile": "http://kent.doddsfamily.us"
+    , "contributions": [
         "code"
+      , "doc"
+      , "infra"
+      , "example"
+      ]
+    }
+  , {
+      "login": "DavidWells"
+    , "name": "David Wells"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/532272?v=3"
+    , "profile": "http://davidwells.io"
+    , "contributions": [
+        "code"
+      ]
+    }
+  , {
+      "login": "abhishekisnot"
+    , "name": "Abhishek Shende"
+    , "avatar_url": "https://avatars.githubusercontent.com/u/802242?v=3"
+    , "html_url": "https://github.com/abhishekisnot"
+    , "contributions": [
+        "code"
+      , "test"
       ]
     }
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 dist
 .opt-in
 .opt-out
+npm-debug.log

--- a/src/kebab-and-camel-casify.js
+++ b/src/kebab-and-camel-casify.js
@@ -18,5 +18,5 @@ function kebabAndCamelCasify(obj) {
       result[key] = val
     }
     return result
-  }, {})
+  }, obj)
 }

--- a/src/kebab-and-camel-casify.test.js
+++ b/src/kebab-and-camel-casify.test.js
@@ -4,7 +4,7 @@ import kebabAndCamelCasify from './kebab-and-camel-casify'
 testUnchanged({boo: 'baz'})
 testUnchanged({boo: {bar: 'baz', foo: 'bar'}})
 
-test({e2e: 'foo'}, {e2E:'foo','e-2-e':'foo', e2e: 'foo'}, 'shallow objects')
+test({e2e: 'foo'}, {e2E: 'foo', 'e-2-e': 'foo', e2e: 'foo'}, 'shallow objects')
 test({fooBar: 'baz'}, {fooBar: 'baz', 'foo-bar': 'baz'}, 'shallow objects')
 
 test({

--- a/src/kebab-and-camel-casify.test.js
+++ b/src/kebab-and-camel-casify.test.js
@@ -4,6 +4,7 @@ import kebabAndCamelCasify from './kebab-and-camel-casify'
 testUnchanged({boo: 'baz'})
 testUnchanged({boo: {bar: 'baz', foo: 'bar'}})
 
+test({e2e: 'foo'}, {e2E:'foo','e-2-e':'foo', e2e: 'foo'}, 'shallow objects')
 test({fooBar: 'baz'}, {fooBar: 'baz', 'foo-bar': 'baz'}, 'shallow objects')
 
 test({


### PR DESCRIPTION
casify should also return original task name to avoid common user errors. For example, for task name
like e2e, it is not obvious to see that it converts to camelCase e2E and kebab-case e-2-e. This
avoids scripts must resolve to string error if user passes in the original task name over camelified
or kebabified task name