### PR TITLE
feat: Allow user to specify envrionment variables for scripts

### DIFF
--- a/bin/p-s.js
+++ b/bin/p-s.js
@@ -36,6 +36,7 @@ var psConfig = getPSConfig()
 
 runPackageScript({
   scriptConfig: getPSConfig().scripts,
+  envConfig: getPSConfig().env,
   scripts: scriptsAndArgs.scripts,
   args: scriptsAndArgs.args,
   options: merge(psConfig.options, {

--- a/bin/p-s.js
+++ b/bin/p-s.js
@@ -35,8 +35,8 @@ var scriptsAndArgs = getScriptsAndArgs(program)
 var psConfig = getPSConfig()
 
 runPackageScript({
-  scriptConfig: getPSConfig().scripts,
-  envConfig: getPSConfig().env,
+  scriptConfig: psConfig.scripts,
+  envConfig: psConfig.env,
   scripts: scriptsAndArgs.scripts,
   args: scriptsAndArgs.args,
   options: merge(psConfig.options, {

--- a/src/get-script-env.js
+++ b/src/get-script-env.js
@@ -1,0 +1,15 @@
+import prefixMatches from 'prefix-matches'
+import kebabAndCamelCasify from './kebab-and-camel-casify'
+
+export default function getScriptEnv(config, input) {
+  if (!config) {
+    return {}
+  }
+  config = kebabAndCamelCasify(config)
+  let env = prefixMatches(input, config)[0]
+  while (!env) {
+    input = input.split('.').slice(0, -1).join('.')
+    env = prefixMatches(input, config)[0]
+  }
+  return env
+}

--- a/src/get-script-env.test.js
+++ b/src/get-script-env.test.js
@@ -1,0 +1,32 @@
+import test from 'ava'
+import getScriptEnv from './get-script-env'
+
+test('works with a nonexistent config', t => {
+  const env = getScriptEnv(undefined, 'wat')
+  t.deepEqual(env, {})
+})
+
+test('allows a prefix to be provided', t => {
+  const env = getScriptEnv({build: {foo: 'bar'}}, 'b')
+  t.deepEqual(env, {foo: 'bar'})
+})
+
+test('allows a multi-level prefix to be provided', t => {
+  const env = getScriptEnv({build: {watch: {baz: 'qux'}}}, 'b.w')
+  t.deepEqual(env, {baz: 'qux'})
+})
+
+test('falls back to using `get` for the full name if no prefix is provided', t => {
+  const env = getScriptEnv({build: {watch: {foo: 'bar'}}}, 'build.watch')
+  t.deepEqual(env, {foo: 'bar'})
+})
+
+test('allows to specify parent script name', t => {
+  const env = getScriptEnv({build: {foo: 'bar'}}, 'build.watch')
+  t.deepEqual(env, {foo: 'bar'})
+})
+
+test('can accept snake-case representation of a camelCase name', t => {
+  const env = getScriptEnv({checkCoverage: {foo: 'bar'}}, 'check-coverage')
+  t.deepEqual(env, {foo: 'bar'})
+})

--- a/src/index.js
+++ b/src/index.js
@@ -3,19 +3,21 @@ import async from 'async'
 import colors from 'colors/safe'
 import isString from 'lodash.isstring'
 import find from 'lodash.find'
+import assign from 'lodash.assign'
 import arrify from 'arrify'
 import getScriptToRun from './get-script-to-run'
 import getScriptsFromConfig from './get-scripts-from-config'
 import getLogger from './get-logger'
+import getScriptEnv from './get-script-env'
 
 const noop = () => {} // eslint-disable-line func-style
 
 export default runPackageScripts
 
-function runPackageScripts({scriptConfig, scripts, args, options}, callback = noop) {
+function runPackageScripts({scriptConfig, scripts, args, envConfig, options}, callback = noop) {
   const scriptNames = arrify(scripts)
   async.map(scriptNames, (scriptName, cb) => {
-    const child = runPackageScript({scriptConfig, options, scriptName, args})
+    const child = runPackageScript({scriptConfig, options, scriptName, args, envConfig})
     if (child.on) {
       child.on('exit', exitCode => cb(null, exitCode))
     } else {
@@ -32,7 +34,7 @@ function runPackageScripts({scriptConfig, scripts, args, options}, callback = no
   })
 }
 
-function runPackageScript({scriptConfig, options = {}, scriptName, args}) {
+function runPackageScript({scriptConfig, options = {}, scriptName, args, envConfig}) {
   const scripts = getScriptsFromConfig(scriptConfig, scriptName)
   const script = getScriptToRun(scripts, scriptName)
   if (!isString(script)) {
@@ -43,10 +45,11 @@ function runPackageScript({scriptConfig, options = {}, scriptName, args}) {
       ref: 'missing-script',
     }
   }
+  const env = getScriptEnv(envConfig, scriptName)
   const command = [script, args].join(' ').trim()
   const log = getLogger(getLogLevel(options))
   log.info(colors.gray('p-s executing: ') + colors.green(command))
-  return spawn(command, {stdio: 'inherit', env: process.env})
+  return spawn(command, {stdio: 'inherit', env: assign({}, process.env, env)})
 }
 
 function getLogLevel({silent, logLevel}) {


### PR DESCRIPTION
**What**:
This allows the user to specify env vars for a script or a set of scripts.

The great thing about it is that it allows to specify a set of env vars for multiple scripts at once. 
So, for example, specifying `env: { test: { foo: 'bar' } }` in the config will run `test.watch`, `test.mystuff` `test.otherstuff` with `foo=bar` as an env var.

**Why**:
Instead of doing this:
```js
scripts: {
  test: {
    bla: "NODE_ENV=TEST MODE=test_mode mocha bla/**/*.js",
    bli: "NODE_ENV=TEST MODE=test_mode mocha bli/**/*.js",
    blo: "NODE_ENV=TEST MODE=test_mode mocha blo/**/*.js",
  }  
}
```
You can do this:

```js
scripts: {
  test: {
    bla: "mocha bla/**/*.js",
    bli: "mocha bli/**/*.js",
    blo: "mocha blo/**/*.js",
  }  
}
env: {
  test: {
    NODE_ENV: "test"
    MODE: "test_mode"
  }
}
```
Much cleaner, isn't it? 😄 

**How**:
Code is pretty much self-explanatory. However if something is unclear, AMA!