### PR TITLE
Fix running as child process

### DIFF
--- a/src/bin/p-s.js
+++ b/src/bin/p-s.js
@@ -19,7 +19,7 @@ program
   .on('--help', onHelp)
   .parse(process.argv)
 
-if (process.argv.length < 3) {
+if (program.args.length < 1) {
   program.outputHelp()
 } else {
   loadAndRun()


### PR DESCRIPTION

**What**:
When running as child process with arguments (like `--config smth`), `process.argv` is never empty, though commander has no args.

Also it would be logically more correct to check `program.args`, since later we use it as `program.args[0]`.

```sh
/Users/nkbt/nkbt/react-swap/node_modules/p-s/dist/bin-utils.js:90
    scripts = program.args[0].split(',');
                             ^

TypeError: Cannot read property 'split' of undefined
    at getScriptsAndArgs (/Users/nkbt/nkbt/react-swap/node_modules/p-s/dist/bin-utils.js:90:30)
    at loadAndRun (/Users/nkbt/nkbt/react-swap/node_modules/p-s/dist/bin/p-s.js:47:56)
    at Object.<anonymous> (/Users/nkbt/nkbt/react-swap/node_modules/p-s/dist/bin/p-s.js:43:3)
 ```


**Why**

I want to proxy p-s from my component like

```js
require('child_process')
  .spawn(ps, ['--config', config].concat(process.argv.slice(2)), {
    cwd: process.cwd(),
    env: process.env,
    stdio: [process.stdin, process.stdout, process.stderr]
  });
```

To avoid adding extra dependency.