### PR TITLE
fix(cli): re-enable parallel scripts

### DIFF
--- a/src/bin-utils.js
+++ b/src/bin-utils.js
@@ -43,15 +43,15 @@ export {getScriptsAndArgs, help, getModuleRequirePath, preloadModule, loadConfig
 /****** implementations ******/
 
 function getScriptsAndArgs(program) {
-  let scripts, args, parallel
-  if (isEmpty(program.parallel)) {
-    scripts = program.args[0].split(',')
-    args = getArgs(program.args.slice(1), program.rawArgs, scripts)
-    parallel = false
-  } else {
+  let scripts = []
+  let args = ''
+  const parallel = !isEmpty(program.parallel)
+  if (parallel) {
     scripts = program.parallel.split(',')
     args = getArgs(program.args, program.rawArgs, scripts)
-    parallel = true
+  } else if (!isEmpty(program.args)) {
+    scripts = program.args[0].split(',')
+    args = getArgs(program.args.slice(1), program.rawArgs, scripts)
   }
   return {scripts, args, parallel}
 }

--- a/src/bin-utils.test.js
+++ b/src/bin-utils.test.js
@@ -32,6 +32,15 @@ test('getScriptsAndArgs: passes args to scripts', t => {
   t.is(args, '--watch --verbose')
 })
 
+test('getScriptsAndArgs: returns empty scripts and args if not parallel and no args', t => {
+  const {args, scripts} = getScriptsAndArgs({
+    args: [],
+    rawArgs: ['node', 'p-s'],
+  })
+  t.is(scripts.length, 0)
+  t.is(args, '')
+})
+
 test('preloadModule: resolves a relative path', t => {
   const relativePath = '../test/fixtures/my-module'
   const val = preloadModule(relativePath)

--- a/src/bin/p-s.js
+++ b/src/bin/p-s.js
@@ -21,14 +21,14 @@ program
   .on('--help', onHelp)
   .parse(process.argv)
 
-if (program.args.length < 1) {
+const scriptsAndArgs = getScriptsAndArgs(program)
+if (scriptsAndArgs.scripts.length < 1) {
   program.outputHelp()
 } else {
   loadAndRun()
 }
 
 function loadAndRun() {
-  const scriptsAndArgs = getScriptsAndArgs(program)
   const psConfig = getPSConfig()
 
   runPackageScript({


### PR DESCRIPTION
**What**:

Fixes an issue with parallel scripts

**Why**:

PR #29 broke the following case:

```
p-s -p lint,test
```

**How**:

This commit fixes it by getting the scripts from the args first and seeing if there are any scripts available to run. If not, then we show the help message.

CC: @giladgo, @abhishekisnot, @rowanoulton, @tleunen, @jisaacks, @nkbt 

Could one of you give this the green light and press the green button please?