### PR TITLE
Use exact dependency versions and add npmrc with save-exact setting

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "p-s": "*",
     "proxyquire": "1.7.10",
     "rimraf": "2.5.3",
-    "semantic-release": "^4.3.5",
+    "semantic-release": "4.3.5",
     "sinon": "1.17.4",
     "validate-commit-msg": "2.6.1"
   },


### PR DESCRIPTION
**What**:
- [x] fix dependency to be exact version
- [x] add `.npmrc` config with save-exact so next time anyone runs `--save` or `--save-dev` - version will be saved without `^`
