### PR TITLE
[wip] Add End-2-End tests for CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-2": "6.11.0",
     "babel-register": "6.11.5",
+    "cli-tester": "1.0.0",
     "codecov": "1.0.1",
     "commitizen": "2.8.2",
     "condition-node-version": "1.3.0",

--- a/src/bin/p-s.test.js
+++ b/src/bin/p-s.test.js
@@ -1,28 +1,26 @@
+/* eslint func-style:0, max-len:[2, 130] */
 import path from 'path'
+import fs from 'fs'
+import os from 'os'
+import {createHash} from 'crypto'
 import test from 'ava'
-import tester from 'cli-tester';
-import fs from 'fs';
-import os from 'os';
-import {createHash} from 'crypto';
+import tester from 'cli-tester/es5'
 
+const babel = require.resolve('babel-cli/bin/babel-node')
 
-const babel = require.resolve('babel-cli/bin/babel-node');
-const cli = require.resolve('./p-s');
-
-
-const hash = string => createHash('md5').update(string).digest('hex');
-const tmpConfig = string => path.join(os.tmpdir(), `tmp-config-${hash(string)}.js`);
-const writeConfig = (file, string) => new Promise(resolve => fs.writeFile(file, string, resolve));
-const rmConfig = (file) => new Promise(resolve => fs.unlink(file, resolve));
+const hash = string => createHash('md5').update(string).digest('hex')
+const tmpConfig = string => path.join(os.tmpdir(), `tmp-config-${hash(string)}.js`)
+const writeConfig = (file, string) => new Promise(resolve => fs.writeFile(file, string, resolve))
+const rmConfig = file => new Promise(resolve => fs.unlink(file, resolve))
 
 
 test('p-s: run without args', t =>
   tester(babel, require.resolve('./p-s'))
     .then(({code, stdout, stderr}) => {
-      t.is(code, 0, 'should exit with code 0');
-      t.regex(stdout, /Usage: p-s \[options]/, 'should show help by default');
-      t.is(stderr, '', 'should not have any errors');
-    }));
+      t.is(code, 0, 'should exit with code 0')
+      t.regex(stdout, /Usage: p-s \[options]/, 'should show help by default')
+      t.is(stderr, '', 'should not have any errors')
+    }))
 
 
 const writeFooBarConfig = ({title}) => writeConfig(tmpConfig(title), `
@@ -38,16 +36,15 @@ const writeFooBarConfig = ({title}) => writeConfig(tmpConfig(title), `
       },
     }
   };
-`);
-const removeFooBarConfig = ({title}) => rmConfig(tmpConfig(title));
+`)
+const removeFooBarConfig = ({title}) => rmConfig(tmpConfig(title))
 
 
 test('p-s: run with config', t => Promise.resolve()
   .then(() => writeFooBarConfig(t))
-  .then(() => tester(babel, require.resolve('./p-s'), '--config', tmpConfig(t.title)))
+  .then(() => tester(babel, require.resolve('./p-s'), '--config', tmpConfig(t.title))) // eslint-disable-line ava/use-t-well
   .then(({stdout}) => {
-    t.regex(stdout, /foo - Foo - foo/, 'should show help for scripts from config');
+    t.regex(stdout, /foo - Foo - foo/, 'should show help for scripts from config')
   })
   .then(() => removeFooBarConfig(t))
-);
-
+)

--- a/src/bin/p-s.test.js
+++ b/src/bin/p-s.test.js
@@ -1,0 +1,53 @@
+import path from 'path'
+import test from 'ava'
+import tester from 'cli-tester';
+import fs from 'fs';
+import os from 'os';
+import {createHash} from 'crypto';
+
+
+const babel = require.resolve('babel-cli/bin/babel-node');
+const cli = require.resolve('./p-s');
+
+
+const hash = string => createHash('md5').update(string).digest('hex');
+const tmpConfig = string => path.join(os.tmpdir(), `tmp-config-${hash(string)}.js`);
+const writeConfig = (file, string) => new Promise(resolve => fs.writeFile(file, string, resolve));
+const rmConfig = (file) => new Promise(resolve => fs.unlink(file, resolve));
+
+
+test('p-s: run without args', t =>
+  tester(babel, require.resolve('./p-s'))
+    .then(({code, stdout, stderr}) => {
+      t.is(code, 0, 'should exit with code 0');
+      t.regex(stdout, /Usage: p-s \[options]/, 'should show help by default');
+      t.is(stderr, '', 'should not have any errors');
+    }));
+
+
+const writeFooBarConfig = ({title}) => writeConfig(tmpConfig(title), `
+  module.exports = {
+    scripts: {
+      foo: {
+        description: 'Foo',
+        script: 'foo',
+      },
+      bar: {
+        description: 'Bar',
+        script: 'bar',
+      },
+    }
+  };
+`);
+const removeFooBarConfig = ({title}) => rmConfig(tmpConfig(title));
+
+
+test('p-s: run with config', t => Promise.resolve()
+  .then(() => writeFooBarConfig(t))
+  .then(() => tester(babel, require.resolve('./p-s'), '--config', tmpConfig(t.title)))
+  .then(({stdout}) => {
+    t.regex(stdout, /foo - Foo - foo/, 'should show help for scripts from config');
+  })
+  .then(() => removeFooBarConfig(t))
+);
+


### PR DESCRIPTION
Fixes #31 

**What**:
- [x] Added `cli-tester`
- [x] Windows/OSX compatible tests
- [x] Add test for running `p-s` without any arguments
- [x] Add test for running with config file but without any arguments
- [ ] More tests

<!-- Why are these changes necessary? -->
**Why**:
Make sure that expected behavior is not broken with different updates


This is WIP, so later will rewrite commit messages, fix code style, etc.

Some of used functions may be abstracted, though I think it is ok to keep them with tests, closer to context.

Would be great to have some more common usecases to test. Maybe another 2-3 to play with. Then anyone could be able to add more tests when new functionality is added.

Feel free to object any of decisions made, let me know what looks good, what is not so.

Cheers!