### PR TITLE
feat(cli): add support for root default script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Put all of your scripts in a file called `package-scripts.js` and use `p-s` in a
 ```javascript
 module.exports = {
   scripts: {
+    default: 'node index.js',
     lint: 'eslint .',
     test: {
       default: 'ava',
@@ -60,8 +61,9 @@ module.exports = {
 Then you can run:
 
 ```console
-npm start lint
-npm start test.watch
+npm start # runs `node index.js`
+npm start lint # runs `eslint .`
+npm start test.watch # runs `ava -w`
 ```
 
 But the fun doesn't end there! You can use a prefix:
@@ -213,6 +215,7 @@ look like (and different ways to run them):
 ```javascript
 module.exports = {
   scripts: {
+    default: 'echo "This runs on `npm start`"', // npm start
     // you can assign a script property to a string
     simple: 'echo "this is easy"', // npm start simple
     test: {
@@ -288,6 +291,12 @@ this. For example:
 So, while you could use a script called `script` and run `npm run script build`, I just think it reads more clearly to
 just use the `start` script and run `npm start build`. It's also nice that it's fewer things to type. You could also use
 the `test` script and then type even less: `npm t build`, but thats just... odd.
+
+Note, often servers are configured to run `npm start` by default to start the server.
+To allow for this case, you can provide a `default` script at the root of your scripts
+which will be run when `p-s` is run without any arguments. Effectively this will
+allow you to have a script run when `npm start` is executed.
+
 
 ## Inspiration
 

--- a/src/bin-utils/initialize/fixtures/_package-scripts.js
+++ b/src/bin-utils/initialize/fixtures/_package-scripts.js
@@ -1,6 +1,9 @@
 module.exports = {
   scripts: {
-    start: 'echo start',
+    default: {
+      default: 'echo start',
+      stuff: 'echo start:stuff'
+    },
     test: 'echo test',
     foo: {
       default: 'echo foo',

--- a/src/bin-utils/initialize/fixtures/_package.json
+++ b/src/bin-utils/initialize/fixtures/_package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "start": "echo start",
+    "start:stuff": "echo start:stuff",
     "test": "echo test",
     "foo": "echo foo",
     "bar": "echo bar",

--- a/src/bin-utils/initialize/index.js
+++ b/src/bin-utils/initialize/index.js
@@ -30,7 +30,11 @@ function generatePackageScriptsFileContents(scripts) {
 function structureScripts(scripts) {
   // start out by giving every script a `default`
   const defaultedScripts = Object.keys(scripts).reduce((obj, key) => {
-    const deepKey = [...key.split(':'), 'default'].join('.')
+    const keyParts = key.split(':')
+    let deepKey = [...keyParts, 'default'].join('.')
+    if (key.indexOf('start') === 0) {
+      deepKey = ['default', ...keyParts.slice(1, keyParts.length), 'default'].join('.')
+    }
     const script = scripts[key]
     set(obj, deepKey, script)
     return obj

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,9 @@ const noop = () => {} // eslint-disable-line func-style, no-empty-function
 export default runPackageScripts
 
 function runPackageScripts({scriptConfig, scripts, args, options}, callback = noop) {
+  if (scripts.length === 0) {
+    scripts = ['default']
+  }
   const scriptNames = arrify(scripts)
   async.map(scriptNames, (scriptName, cb) => {
     const child = runPackageScript({scriptConfig, options, scriptName, args})

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -83,6 +83,11 @@ test.cb('runs scripts in parallel if given an array of input', t => {
   })
 })
 
+test('runs the default script if no scripts provided', t => {
+  const {command} = testSpawnCall(t, {default: 'echo foo'}, [])
+  t.is(command, `echo foo`)
+})
+
 // util functions
 
 function testSpawnCallWithDefaults(t, options, stubOverrides) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Adds support for the use case where running `p-s` without arguments will run `scripts.default`

<!-- Why are these changes necessary? -->
**Why**:

Because often servers are configured to run `npm start` by default.

<!-- How were these changes implemented? -->
**How**:

- check for any arguments and default to `['default']` if no scripts are given.
- Update the `init` script to account for a `start` script

<!-- feel free to add additional comments -->

Closes #33