### PR TITLE
feat(PATH): add npm bin to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,12 @@ module.exports = {
     simple: 'echo "this is easy"', // npm start simple
     test: {
       default: {
-        script: 'echo "test things!"', // npm start test
-        description: 'just pass it on to npm... Do not take this config very seriously :-)',
+        script: 'ava', // npm start test
+        description: 'Run tests with ava',
+        // your scripts will be run with node_modules/.bin in the PATH, so you can use locally installed packages.
+        // this is done in a cross-platform way, so your scripts will work on Mac and Windows :)
+        // NOTE: if you need to set environment variables, I recommend you check out the cross-env package, which works
+        // gret with p-s
       },
       otherStuff: {
         // this one can be executed two different ways:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "commander": "2.9.0",
     "find-up": "1.1.2",
     "lodash": "4.14.0",
+    "manage-path": "2.0.0",
     "prefix-matches": "0.0.9",
     "shell-escape": "0.2.0",
     "spawn-command": "0.0.2"

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 import spawn from 'spawn-command'
 import async from 'async'
 import colors from 'colors/safe'
-import {isString, find} from 'lodash'
+import {isString, find, clone} from 'lodash'
+import {sync as findUpSync} from 'find-up'
+import managePath from 'manage-path'
 import arrify from 'arrify'
 import getScriptToRun from './get-script-to-run'
 import getScriptsFromConfig from './get-scripts-from-config'
@@ -45,7 +47,7 @@ function runPackageScript({scriptConfig, options = {}, scriptName, args}) {
   const command = [script, args].join(' ').trim()
   const log = getLogger(getLogLevel(options))
   log.info(colors.gray('p-s executing: ') + colors.green(command))
-  return spawn(command, {stdio: 'inherit', env: process.env})
+  return spawn(command, {stdio: 'inherit', env: getEnv()})
 }
 
 function getLogLevel({silent, logLevel}) {
@@ -56,4 +58,14 @@ function getLogLevel({silent, logLevel}) {
   } else {
     return undefined
   }
+}
+
+function getEnv() {
+  const env = clone(process.env)
+  const alterPath = managePath(env)
+  const npmBin = findUpSync('node_modules/.bin')
+  if (npmBin) {
+    alterPath.unshift(npmBin)
+  }
+  return env
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

This will search for a local node_modules/.bin directory and attempt to add it to the PATH (in a cross-platform way using `manage-path`).

<!-- Why are these changes necessary? -->
**Why**:

So people can use these just as they would normal npm scripts. The only case where the PATH doesn't actually contain the npm bin is when you run the `p-s` script directly (rather than using npm scripts). This is an edge case, but it's still handy

<!-- How were these changes implemented? -->
**How**:

Use `find-up` to find the `node_modules/.bin` and `mange-path` to add it to the PATH in a cross-platform way

<!-- feel free to add additional comments -->
Closes #27