### PR TITLE
fix(default): Now default scripts will be a fallback only

### DIFF
--- a/src/get-script-to-run.js
+++ b/src/get-script-to-run.js
@@ -1,3 +1,4 @@
+import {each, cloneDeep, isPlainObject} from 'lodash'
 import prefixMatches from 'prefix-matches'
 import resolveScriptObjectToString from './resolve-script-object-to-string'
 import kebabAndCamelCasify from './kebab-and-camel-casify'
@@ -6,6 +7,29 @@ export default getScriptToRun
 
 function getScriptToRun(config, input) {
   config = kebabAndCamelCasify(config)
-  const script = prefixMatches(input, config)[0]
+  // remove the default objects/strings so we can check if the prefix works with another script first
+  const defaultlessConfig = removeDefaults(cloneDeep(config))
+  const scriptString = getScriptString(defaultlessConfig, input)
+  if (scriptString) {
+    return scriptString
+  } else {
+    // fallback to the defaults if no other script was found with the given input
+    return getScriptString(config, input)
+  }
+}
+
+function getScriptString(config, input) {
+  const [script] = prefixMatches(input, config)
   return resolveScriptObjectToString(script)
+}
+
+function removeDefaults(object) {
+  each(object, (value, key) => {
+    if (key === 'default') {
+      delete object[key]
+    } else if (isPlainObject(value)) {
+      object[key] = removeDefaults(value)
+    }
+  })
+  return object
 }

--- a/src/get-script-to-run.test.js
+++ b/src/get-script-to-run.test.js
@@ -20,3 +20,14 @@ test('can accept snake-case representation of a camelCase name', t => {
   const script = getScriptToRun({checkCoverage: 'checking coverage'}, 'check-coverage')
   t.is(script, 'checking coverage')
 })
+
+test('fallsback to `default` if no prefix is found', t => {
+  const scripts = {foo: {default: 'echo "default"', dee: 'echo "dee"'}}
+  const usesDefault = getScriptToRun(scripts, 'foo')
+  const defaultIsPrefixFallback = getScriptToRun(scripts, 'foo.def')
+  const script = getScriptToRun(scripts, 'foo.de')
+
+  t.is(usesDefault, 'echo "default"')
+  t.is(defaultIsPrefixFallback, 'echo "default"')
+  t.is(script, 'echo "dee"')
+})


### PR DESCRIPTION
**What**:

This adds logic to check first for non-default scripts, then fallback on
default scripts if none are found that satisfies the input

**Why**:

Because #25

**How**:

Create a clone of the config object and remove all default scripts,
check the prefix with that, if none is found attempt again with the
original config object.

Closes #25

BREAKING CHANGE: You're unlikely to have this problem, but if you had a
script that matched the prefix `def` for example, the default script
would be run. Now, your specific script will be run instead.