### PR TITLE
feat(autocomplete): add `completion` script to install autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ If you do this, you may also be interested in installing the shell autocompletio
 nps completion <optionally-your-bash-profile-file>
 ```
 
-The bash profile file defaults to `~/.bash_profile`. Special thanks to the [`omelette`][omelette] package for making
-this so easy.
+The bash profile file defaults to `~/.bash_profile` for bash and `~/.zshrc` for zsh. Special thanks to the
+[`omelette`][omelette] package for making this so easy.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,14 @@ npm install --global p-s
 ```
 
 From here you can use `p-s` on the command line via one of the installed aliases: `p-s`, `package-scripts`, or `nps`.
-In the future, this may support autocomplete capabilities. Check out #28 for updates on this.
+If you do this, you may also be interested in installing the shell autocompletion script. Do so by running:
+
+```
+nps completion <optionally-your-bash-profile-file>
+```
+
+The bash profile file defaults to `~/.bash_profile`. Special thanks to the [`omelette`][omelette] package for making
+this so easy.
 
 ## Getting started
 
@@ -392,3 +399,4 @@ MIT
 [scripty]: https://npmjs.com/package/scripty
 [npm scripts]: https://docs.npmjs.com/misc/scripts
 [video]: http://kcd.im/p-s-video
+[omelette]: https://npmjs.com/package/omelette

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -1,9 +1,12 @@
 /* eslint prefer-template:"off", no-var:"off", max-len:[2, 200] */ // this file runs in node 0.10.0
+var transpile = 'babel --copy-files --out-dir dist --ignore *.test.js,fixtures src'
+
 var nodeVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1])
 var validate = ['build', 'test']
 if (nodeVersion >= 4) {
   validate.push('lint') // we can't run linting on node versions < 4
 }
+
 module.exports = {
   scripts: {
     commit: {
@@ -21,8 +24,13 @@ module.exports = {
       },
     },
     build: {
-      description: 'deletes the `dist` directory and transpiles all relevant `src` to the `dist`',
-      script: 'rimraf dist && babel --copy-files --out-dir dist --ignore *.test.js,fixtures src',
+      default: {
+        description: 'deletes the `dist` directory and transpiles all relevant `src` to the `dist`',
+        script: 'rimraf dist && ' + transpile,
+      },
+      watch: {
+        script: 'rimraf dist && ' + transpile + ' --watch',
+      },
     },
     lint: {
       description: 'lint the code with eslint',

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -1,5 +1,6 @@
 /* eslint prefer-template:"off", no-var:"off", max-len:[2, 200] */ // this file runs in node 0.10.0
 var transpile = 'babel --copy-files --out-dir dist --ignore *.test.js,fixtures src'
+var cleanDist = 'rimraf dist'
 
 var nodeVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1])
 var validate = ['build', 'test']
@@ -26,10 +27,10 @@ module.exports = {
     build: {
       default: {
         description: 'deletes the `dist` directory and transpiles all relevant `src` to the `dist`',
-        script: 'rimraf dist && ' + transpile,
+        script: [cleanDist, transpile].join('&&'),
       },
       watch: {
-        script: 'rimraf dist && ' + transpile + ' --watch',
+        script: [cleanDist, transpile + ' --watch'].join('&&'),
       },
     },
     lint: {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "find-up": "1.1.2",
     "lodash": "4.14.0",
     "manage-path": "2.0.0",
+    "omelette": "0.3.1",
     "prefix-matches": "0.0.9",
     "shell-escape": "0.2.0",
     "spawn-command": "0.0.2"

--- a/src/bin-utils/autocomplete/index.js
+++ b/src/bin-utils/autocomplete/index.js
@@ -15,9 +15,8 @@ function autocomplete(config = {}) {
   }
 }
 
-function install(destination = '~/.bash_profile') {
+function install(destination) {
   complete.setupShellInitFile(destination)
-  return destination
 }
 
 function getScripts(scriptsObject, prefix = '', allScripts = []) {

--- a/src/bin-utils/autocomplete/index.js
+++ b/src/bin-utils/autocomplete/index.js
@@ -1,0 +1,38 @@
+/* eslint no-invalid-this:"off" */
+import omelette from 'omelette'
+import {includes, isPlainObject, kebabCase} from 'lodash'
+
+const complete = omelette('nps <script>')
+
+export {autocomplete as default, install}
+
+function autocomplete(config = {}) {
+  complete.on('script', onScript)
+  complete.init()
+
+  function onScript() {
+    this.reply(getScripts(config.scripts))
+  }
+}
+
+function install(destination = '~/.bash_profile') {
+  complete.setupShellInitFile(destination)
+  return destination
+}
+
+function getScripts(scriptsObject, prefix = '', allScripts = []) {
+  const excludedKeys = ['default', 'script', 'description']
+  return Object.keys(scriptsObject).reduce((acc, key) => {
+    if (includes(excludedKeys, key)) {
+      return acc
+    }
+    const value = scriptsObject[key]
+    const kebabKey = kebabCase(key)
+    const deepKey = prefix ? `${prefix}.${kebabKey}` : kebabKey
+    acc.push(deepKey)
+    if (isPlainObject(value)) {
+      getScripts(value, deepKey, acc)
+    }
+    return acc
+  }, allScripts)
+}

--- a/src/bin-utils/autocomplete/index.test.js
+++ b/src/bin-utils/autocomplete/index.test.js
@@ -38,15 +38,6 @@ test('install calls setupShellInitFile with the given destination', t => {
   t.is(actualDestination, destination)
 })
 
-test('install defaults to ~/.bash_profile', t => {
-  const {install, setupShellInitFileSpy} = getInstall()
-  const expectedDestination = '~/.bash_profile'
-  install()
-  const [actualDestination] = setupShellInitFileSpy.firstCall.args
-  t.true(setupShellInitFileSpy.calledOnce)
-  t.is(actualDestination, expectedDestination)
-})
-
 function getAutocomplete() {
   const onSpy = spy()
   const initSpy = spy()

--- a/src/bin-utils/autocomplete/index.test.js
+++ b/src/bin-utils/autocomplete/index.test.js
@@ -1,0 +1,73 @@
+import test from 'ava'
+import {spy} from 'sinon'
+import proxyquire from 'proxyquire'
+
+test('inits omelette', t => {
+  const {autocomplete, initSpy} = getAutocomplete()
+  autocomplete()
+  t.true(initSpy.calledOnce)
+})
+
+test('calls this.reply with the available scripts', t => {
+  const stubConfig = {
+    scripts: {
+      build: {default: {script: 'build'}, watch: 'build.watch', main: {umd: 'build.main.umd', default: 'build.main'}},
+      lint: {default: {script: 'lint', description: 'lint things'}, watch: 'lint.watch'},
+      test: 'test',
+      camelCase: 'camelCase',
+      cover: {description: 'this is a description', script: 'this is the script'},
+    },
+  }
+  const expectedReplyArgs = [
+    'build', 'build.watch', 'build.main', 'build.main.umd',
+    'lint', 'lint.watch',
+    'test', 'camel-case', 'cover',
+  ]
+  const {autocomplete, getReplyArgs} = getAutocomplete()
+  autocomplete(stubConfig)
+  const actualReplyArgs = getReplyArgs()
+  t.deepEqual(actualReplyArgs, expectedReplyArgs)
+})
+
+test('install calls setupShellInitFile with the given destination', t => {
+  const {install, setupShellInitFileSpy} = getInstall()
+  const destination = '~/.my_bash_profile'
+  install(destination)
+  const [actualDestination] = setupShellInitFileSpy.firstCall.args
+  t.true(setupShellInitFileSpy.calledOnce)
+  t.is(actualDestination, destination)
+})
+
+test('install defaults to ~/.bash_profile', t => {
+  const {install, setupShellInitFileSpy} = getInstall()
+  const expectedDestination = '~/.bash_profile'
+  install()
+  const [actualDestination] = setupShellInitFileSpy.firstCall.args
+  t.true(setupShellInitFileSpy.calledOnce)
+  t.is(actualDestination, expectedDestination)
+})
+
+function getAutocomplete() {
+  const onSpy = spy()
+  const initSpy = spy()
+  const omelette = spy(() => {
+    return {on: onSpy, init: initSpy}
+  })
+  const autocomplete = proxyquire('./index', {omelette}).default
+  return {autocomplete, getReplyArgs, initSpy}
+
+  function getReplyArgs() {
+    const [, replier] = onSpy.firstCall.args
+    const reply = spy()
+    const context = {reply}
+    replier.call(context)
+    return reply.firstCall.args[0]
+  }
+}
+
+function getInstall() {
+  const setupShellInitFileSpy = spy()
+  const omelette = spy(() => ({setupShellInitFile: setupShellInitFileSpy}))
+  const {install} = proxyquire('./index', {omelette})
+  return {install, setupShellInitFileSpy}
+}

--- a/src/bin-utils/index.js
+++ b/src/bin-utils/index.js
@@ -6,6 +6,7 @@ import colors from 'colors/safe'
 import getLogger from '../get-logger'
 import {resolveScriptObjectToScript} from '../resolve-script-object-to-string'
 import initialize from './initialize'
+import {default as autocomplete, install as installAutocomplete} from './autocomplete'
 
 const log = getLogger()
 
@@ -36,7 +37,7 @@ const loadConfig = getAttemptModuleRequireFn(function onFail(configPath, require
 })
 
 export {
-  getScriptsAndArgs, initialize, help,
+  getScriptsAndArgs, initialize, help, autocomplete, installAutocomplete,
   getModuleRequirePath, preloadModule, loadConfig,
 }
 

--- a/src/bin/p-s.js
+++ b/src/bin/p-s.js
@@ -87,7 +87,7 @@ function onInit() {
     'You may also want to install the package globally and installing autocomplete script. You can do so by running\n' +
     '  npm install --global p-s\n' +
     '  nps completion <optionally-your-bash-profile-file>\n' +
-    'The bash profile file defaults to ~/.bash_profile'
+    'The bash profile file defaults to ~/.bash_profile for bash and ~/.zshrc for zsh'
   ))
 }
 
@@ -98,9 +98,11 @@ function onHelp() {
 
 function onRequestToInstallCompletion() {
   shouldRun = false
-  const [, bin,, destination] = process.argv
-  const finalDestination = installAutocomplete(destination)
-  log.info(
-    `Autocompletion has been set up and installed into ${colors.bold.green(finalDestination)} for ${colors.bold(bin)}`,
-  )
+  const [,,, destination] = process.argv
+  if (destination) {
+    log.info(`Installing p-s autocomplete into ${destination}`)
+  } else {
+    log.info('Installing p-s autocomplete into the default for your current terminal')
+  }
+  installAutocomplete(destination)
 }

--- a/src/bin/p-s.js
+++ b/src/bin/p-s.js
@@ -104,5 +104,9 @@ function onRequestToInstallCompletion() {
   } else {
     log.info('Installing p-s autocomplete into the default for your current terminal')
   }
+  log.info(
+    `You're going to need to either resource that file, or open a new instance of ` +
+    'the terminal to get autocomplete to start working'
+  )
   installAutocomplete(destination)
 }


### PR DESCRIPTION
**What**: This adds a command called `completion` which installs the
autocomplete shell script. It also adds the logic to provide the
autocompletion.

**Why**: Because that's pretty swell!

**How**: Using omelette which is pretty awesome.

@tleunen, @SamVerschueren, and @jamischarles, do ya'll mind trying this out?

```
npm install --global p-s@beta
nps completion <path-to-your-bash-profile-file>
nps <tab>
```

`<path-to-your-bash-profile-file>` defaults to `~/.bash_profile`.

I'd appreciate a code review as well :)