### PR TITLE
feat(cli): allow initializing a YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ module.exports = {
 }
 ```
 
-Or if case you prefer YAML, here's an example of how that would look in a `package-scripts.yml` file:
+Or in case you prefer YAML, here's an example of how that would look in a `package-scripts.yml` file:
 
 ```yml
 scripts:
@@ -194,9 +194,13 @@ If you're already using npm scripts, you can get up and going really quickly wit
 ```
 ./node_modules/.bin/nps init
 ```
+or
+```
+./node_modules/.bin/nps init --type yaml
+```
 
-This will use your `package.json` `scripts` to generate a `package-scripts.js` file and update your `scripts` to
-utilize the `nps` binary.
+This will use your `package.json` `scripts` to generate a `package-scripts.js` (respectively a `package-scripts.yml`)
+file and update your `scripts` to utilize the `nps` binary.
 
 ## API
 

--- a/src/bin-utils/index.js
+++ b/src/bin-utils/index.js
@@ -90,9 +90,9 @@ function getArgs(args, rawArgs, scripts) {
   const allArgs = rawArgs.slice(2)
   const psArgs = ['-p', '--parallel', '-c', '--config', '-r', '--require']
   const psFlags = ['-s', '--silent']
-  const cleanedArgs = remove(allArgs, (item, index, arry) => {
+  const cleanedArgs = remove(allArgs, (item, index, array) => {
     const isArgOrFlag = includes(psArgs, item) || includes(psFlags, item)
-    const isArgValue = includes(psArgs, arry[index - 1])
+    const isArgValue = includes(psArgs, array[index - 1])
     const isInScripts = includes(scripts, item)
     return !isArgOrFlag && !isArgValue && !isInScripts
   })

--- a/src/bin-utils/initialize/fixtures/_package-scripts.yml
+++ b/src/bin-utils/initialize/fixtures/_package-scripts.yml
@@ -1,0 +1,14 @@
+scripts:
+  default:
+    default: echo start
+    stuff: 'echo start:stuff'
+  test: echo test
+  foo:
+    default: echo foo
+    bar:
+      default: 'echo foo:bar'
+      baz: 'echo foo:bar:baz'
+  bar: echo bar
+  foo-bar: echo foo-bar
+  foobar: echo "foo bar"
+  baz: echo 'baz buzz'

--- a/src/bin-utils/initialize/index.test.js
+++ b/src/bin-utils/initialize/index.test.js
@@ -3,7 +3,7 @@ import {resolve} from 'path'
 import {readFileSync} from 'fs'
 import {spy} from 'sinon'
 
-test('normal case initialize', () => {
+test('initialize JS normally', () => {
   const packageScriptsDestination = resolve('./src/bin-utils/initialize/fixtures/package-scripts.js')
   const packageJsonDestination = resolve('./src/bin-utils/initialize/fixtures/_package.json')
   const expectedPackageScripts = readFileSync(resolve('./src/bin-utils/initialize/fixtures/_package-scripts.js'), 'utf-8')
@@ -21,14 +21,46 @@ test('normal case initialize', () => {
 
   initialize()
 
-  const [packageScriptsDestinationResult, packageScriptsStringResult] = mockWriteFileSync.firstCall.args
-  const [packageJsonDestinationReuslt, packageJsonStringResult] = mockWriteFileSync.secondCall.args
+  const [packageScriptsDestinationResult, packageScriptsStringResult] = mockWriteFileSync.secondCall.args
+  const [packageJsonDestinationResult, packageJsonStringResult] = mockWriteFileSync.firstCall.args
   const {scripts: packageJsonScripts} = JSON.parse(packageJsonStringResult)
 
   expect(mockWriteFileSync.calledTwice)
   expect(packageScriptsDestinationResult).toBe(packageScriptsDestination)
   expect(packageScriptsStringResult).toBe(expectedPackageScripts)
-  expect(packageJsonDestinationReuslt).toBe(packageJsonDestination)
+  expect(packageJsonDestinationResult).toBe(packageJsonDestination)
+  expect(packageJsonScripts).toEqual({
+    start: 'nps',
+    test: 'nps test',
+  })
+})
+
+test('initialize YML normally', () => {
+  const packageScriptsDestination = resolve('./src/bin-utils/initialize/fixtures/package-scripts.yml')
+  const packageJsonDestination = resolve('./src/bin-utils/initialize/fixtures/_package.json')
+  const expectedPackageScripts = readFileSync(resolve('./src/bin-utils/initialize/fixtures/_package-scripts.yml'), 'utf-8')
+  const mockWriteFileSync = spy()
+  const mockFindUpSync = spy(file => {
+    if (file === 'package.json') {
+      return packageJsonDestination
+    }
+    throw new Error('Should not look for anything but package.json')
+  })
+  jest.resetModules()
+  jest.mock('find-up', () => ({sync: mockFindUpSync}))
+  jest.mock('fs', () => ({writeFileSync: mockWriteFileSync}))
+  const initialize = require('./index').default
+
+  initialize('yaml')
+
+  const [packageScriptsDestinationResult, packageScriptsStringResult] = mockWriteFileSync.secondCall.args
+  const [packageJsonDestinationResult, packageJsonStringResult] = mockWriteFileSync.firstCall.args
+  const {scripts: packageJsonScripts} = JSON.parse(packageJsonStringResult)
+
+  expect(mockWriteFileSync.calledTwice)
+  expect(packageScriptsDestinationResult).toBe(packageScriptsDestination)
+  expect(packageScriptsStringResult).toBe(expectedPackageScripts)
+  expect(packageJsonDestinationResult).toBe(packageJsonDestination)
   expect(packageJsonScripts).toEqual({
     start: 'nps',
     test: 'nps test',
@@ -50,7 +82,7 @@ test('initialize without a test script should not add a test to the package.json
   const initialize = require('./index').default
 
   initialize()
-  const [, packageJsonStringResult] = mockWriteFileSync.secondCall.args
+  const [, packageJsonStringResult] = mockWriteFileSync.firstCall.args
   const {scripts: packageJsonScripts} = JSON.parse(packageJsonStringResult)
 
   expect(packageJsonScripts).toEqual({

--- a/src/bin/nps.js
+++ b/src/bin/nps.js
@@ -105,10 +105,6 @@ function onInit() {
 function getConfigType() {
   let configType
 
-  if (includes(process.argv, '-t')) {
-    configType = process.argv[indexOf(process.argv, '-t') + 1]
-  }
-
   if (includes(process.argv, '--type')) {
     configType = process.argv[indexOf(process.argv, '--type') + 1]
   }

--- a/src/bin/nps.js
+++ b/src/bin/nps.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint no-process-exit: "off" */
 import findUp from 'find-up'
-import {merge, includes, indexOf, isUndefined} from 'lodash'
+import {merge, includes, indexOf} from 'lodash'
 import program from 'commander'
 import colors from 'colors/safe'
 import runPackageScript from '../index'

--- a/src/bin/nps.js
+++ b/src/bin/nps.js
@@ -103,17 +103,7 @@ function onInit() {
 }
 
 function getConfigType() {
-  let configType
-
-  if (includes(process.argv, '--type')) {
-    configType = process.argv[indexOf(process.argv, '--type') + 1]
-  }
-
-  if (isUndefined(configType)) {
-    return 'js'
-  }
-
-  return configType
+  return includes(process.argv, '--type') ? process.argv[indexOf(process.argv, '--type') + 1] : 'js'
 }
 
 function onHelp() {

--- a/src/bin/nps.js
+++ b/src/bin/nps.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint no-process-exit: "off" */
 import findUp from 'find-up'
-import {merge, includes} from 'lodash'
+import {merge, includes, indexOf, isUndefined} from 'lodash'
 import program from 'commander'
 import colors from 'colors/safe'
 import runPackageScript from '../index'
@@ -88,7 +88,7 @@ function getPSConfigFilepath() {
 
 function onInit() {
   shouldRun = false
-  const {packageScriptsPath} = initialize()
+  const {packageScriptsPath} = initialize(getConfigType())
   log.info(`Your scripts have been saved at ${colors.green(packageScriptsPath)}`)
   log.info(colors.gray(
     'Check out your scripts in there. Go ahead and update them and add descriptions to the ones that need it'
@@ -100,6 +100,24 @@ function onInit() {
     '  nps completion <optionally-your-bash-profile-file>\n' +
     'The bash profile file defaults to ~/.bash_profile for bash and ~/.zshrc for zsh'
   ))
+}
+
+function getConfigType() {
+  let configType
+
+  if (includes(process.argv, '-t')) {
+    configType = process.argv[indexOf(process.argv, '-t') + 1]
+  }
+
+  if (includes(process.argv, '--type')) {
+    configType = process.argv[indexOf(process.argv, '--type') + 1]
+  }
+
+  if (isUndefined(configType)) {
+    return 'js'
+  }
+
+  return configType
 }
 
 function onHelp() {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: #66 

<!-- Why are these changes necessary? -->
**Why**: in order to allow those who prefer YAML to JS to use `nps` in their existing projects

<!-- How were these changes implemented? -->
**How**: by checking for the presence of the type modifier and, if present, leveraging [js-yaml](https://github.com/nodeca/js-yaml) to convert & dump the user's configuration


<!-- feel free to add additional comments -->

allow using the `package.json` of an existing project to generate a `package-scripts.yml` file in

order to make it easier to start using `nps`

closes #66