### PR TITLE
chore(devDeps): add missing peer dep of babel-plugin-module-resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-cli": "6.11.4",
     "babel-eslint": "6.1.2",
     "babel-jest": "15.0.0",
+    "babel-plugin-module-resolver": "2.3.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-2": "6.11.0",
     "babel-register": "6.11.5",


### PR DESCRIPTION
`eslint-import-resolver-babel-module` was complaining