### PR TITLE
Add life cyle pre and post commands

### DIFF
--- a/src/get-script-to-run.js
+++ b/src/get-script-to-run.js
@@ -1,6 +1,6 @@
 import {each, cloneDeep, isPlainObject} from 'lodash'
 import prefixMatches from 'prefix-matches'
-import resolveScriptObjectToString from './resolve-script-object-to-string'
+import resolveScriptObjectToLifecycleObject from './resolve-script-object-to-string'
 import kebabAndCamelCasify from './kebab-and-camel-casify'
 
 export default getScriptToRun
@@ -9,18 +9,18 @@ function getScriptToRun(config, input) {
   config = kebabAndCamelCasify(config)
   // remove the default objects/strings so we can check if the prefix works with another script first
   const defaultlessConfig = removeDefaults(cloneDeep(config))
-  const scriptString = getScriptString(defaultlessConfig, input)
-  if (scriptString) {
+  const scriptString = getScriptStringWithLifecycle(defaultlessConfig, input)
+  if (scriptString && scriptString.script) {
     return scriptString
   } else {
     // fallback to the defaults if no other script was found with the given input
-    return getScriptString(config, input)
+    return getScriptStringWithLifecycle(config, input)
   }
 }
 
-function getScriptString(config, input) {
+function getScriptStringWithLifecycle(config, input) {
   const [script] = prefixMatches(input, config)
-  return resolveScriptObjectToString(script)
+  return resolveScriptObjectToLifecycleObject(script)
 }
 
 function removeDefaults(object) {

--- a/src/get-script-to-run.test.js
+++ b/src/get-script-to-run.test.js
@@ -1,30 +1,30 @@
 import getScriptToRun from './get-script-to-run'
 
 test('allows a prefix to be provided', () => {
-  const script = getScriptToRun({build: 'stuff'}, 'b')
+  const {script} = getScriptToRun({build: 'stuff'}, 'b')
   expect(script).toBe('stuff')
 })
 
 test('allows a multi-level prefix to be provided', () => {
-  const script = getScriptToRun({build: {watch: 'watch stuff'}}, 'b.w')
+  const {script} = getScriptToRun({build: {watch: 'watch stuff'}}, 'b.w')
   expect(script).toBe('watch stuff')
 })
 
 test('falls back to using `get` for the full name if no prefix is provided', () => {
-  const script = getScriptToRun({build: {watch: 'watch stuff'}}, 'build.watch')
+  const {script} = getScriptToRun({build: {watch: 'watch stuff'}}, 'build.watch')
   expect(script).toBe('watch stuff')
 })
 
 test('can accept snake-case representation of a camelCase name', () => {
-  const script = getScriptToRun({checkCoverage: 'checking coverage'}, 'check-coverage')
+  const {script} = getScriptToRun({checkCoverage: 'checking coverage'}, 'check-coverage')
   expect(script).toBe('checking coverage')
 })
 
 test('fallsback to `default` if no prefix is found', () => {
   const scripts = {foo: {default: 'echo "default"', dee: 'echo "dee"'}}
-  const usesDefault = getScriptToRun(scripts, 'foo')
-  const defaultIsPrefixFallback = getScriptToRun(scripts, 'foo.def')
-  const script = getScriptToRun(scripts, 'foo.de')
+  const {script: usesDefault} = getScriptToRun(scripts, 'foo')
+  const {script: defaultIsPrefixFallback} = getScriptToRun(scripts, 'foo.def')
+  const {script} = getScriptToRun(scripts, 'foo.de')
 
   expect(usesDefault).toBe('echo "default"')
   expect(defaultIsPrefixFallback).toBe('echo "default"')

--- a/src/resolve-script-object-to-string.js
+++ b/src/resolve-script-object-to-string.js
@@ -1,25 +1,25 @@
 import {isString, isPlainObject, isUndefined} from 'lodash'
 
-export {resolveScriptObjectToString as default, resolveScriptObjectToScript}
+export {resolveScriptObjectToLifecycleObject as default, resolveScriptObjectToScript}
 
-function resolveScriptObjectToString(script) {
+function resolveScriptObjectToLifecycleObject(script) {
   const scriptObj = resolveScriptObjectToScript(script)
   if (isPlainObject(scriptObj)) {
-    return scriptObj.script
+    return scriptObj
   }
   return undefined
 }
 
 function resolveScriptObjectToScript(script) {
   if (isPlainObject(script)) {
-    return resolvePlainObjectToScript(script)
+    return resolvePlainObjectToScriptLifecycle(script)
   } else if (isString(script)) {
     return {script}
   }
   return undefined
 }
 
-function resolvePlainObjectToScript(script) {
+function resolvePlainObjectToScriptLifecycle(script) {
   if (!isUndefined(script.script)) {
     return script
   }

--- a/src/resolve-script-object-to-string.test.js
+++ b/src/resolve-script-object-to-string.test.js
@@ -6,18 +6,19 @@ test('returns undefined if a script cannot be resolved to a string', () => {
 })
 
 test('returns the string if given a string', () => {
-  expect('hello').toBe(resolveScriptObjectToString('hello'))
+  const {script} = resolveScriptObjectToString('hello')
+  expect('hello').toBe(script)
 })
 
 test('script can be an object', () => {
   const lintCommand = 'eslint .'
-  const command = resolveScriptObjectToString({script: lintCommand})
+  const {script: command} = resolveScriptObjectToString({script: lintCommand})
   expect(command).toBe(lintCommand)
 })
 
 test('get the default from the script object', () => {
   const buildCommand = 'webpack'
-  const command = resolveScriptObjectToString({default: {script: buildCommand}})
+  const {script: command} = resolveScriptObjectToString({default: {script: buildCommand}})
   expect(command).toBe(buildCommand)
 })
 
@@ -27,7 +28,7 @@ test('returns undefined if the object with default cannot be resolved to a strin
 })
 
 test('resolves default to the script if it is a string', () => {
-  const result = resolveScriptObjectToString({default: 'string'})
+  const {script: result} = resolveScriptObjectToString({default: 'string'})
   expect(result).toBe('string')
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3983,6 +3983,10 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
+readline-sync@1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.5.tgz#c70d2b1473ecabc1e4d533cbaf3e8249fb77e992"
+
 readline2@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"


### PR DESCRIPTION
There are breaking tests, I am not sure how to fix 2 of them, feedback welcome

**What**:
Implement lifecycle pre and post commands for scripts, based on
https://github.com/kentcdodds/p-s/issues/67#issuecomment-251704554

**Why**:
Add a new feature

**How**:
By returning a `script` of shape

```
{
  pre: ...,
  script: ...,
  post: ...,
}
```
object instead of a string, and running the commands if present in the order of `pre` followed by `script` and then `post`