### PR TITLE
fix(deps): remove bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "license": "MIT",
   "dependencies": {
     "arrify": "^1.0.1",
-    "bluebird": "^3.4.7",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "find-up": "^2.1.0",
@@ -48,6 +47,7 @@
     "cli-tester": "^2.0.0",
     "codecov": "^1.0.1",
     "commitizen": "^2.9.5",
+    "concurrently": "^3.1.0",
     "condition-node-version": "^1.3.0",
     "cross-env": "^3.1.4",
     "cz-conventional-changelog": "^1.2.0",
@@ -56,7 +56,6 @@
     "husky": "^0.13.1",
     "jest-cli": "^18.1.0",
     "opt-cli": "^1.5.1",
-    "concurrently": "^3.1.0",
     "p-s": "*",
     "rimraf": "^2.5.4",
     "semantic-release": "^6.3.6",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import spawn from 'spawn-command-with-kill'
-import Promise from 'bluebird'
 import chalk from 'chalk'
 import {isString, clone} from 'lodash'
 import {sync as findUpSync} from 'find-up'

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,5 @@
 /* eslint import/newline-after-import:0, global-require:0 */
 import {resolve} from 'path'
-import Promise from 'bluebird'
 import {spy} from 'sinon'
 import chalk from 'chalk'
 import managePath from 'manage-path'

--- a/yarn.lock
+++ b/yarn.lock
@@ -936,7 +936,7 @@ bluebird@2.9.6:
   version "2.9.6"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.9.6.tgz#1fc3a6b1685267dc121b5ec89b32ce069d81ab7d"
 
-bluebird@3.4.7, bluebird@^3.4.1, bluebird@^3.4.6, bluebird@^3.4.7:
+bluebird@3.4.7, bluebird@^3.4.1, bluebird@^3.4.6:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
 
@@ -4724,6 +4724,10 @@ strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
 strip-json-comments@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
+
+supports-color@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**What**: this removes the `bluebird` dependency

**Why**: we're dropping support for <= Node v4, so we can use native
Promises

**How**: remove all references to `bluebird`

BREAKING CHANGE: This package now depends on native promises.
